### PR TITLE
chore: correct namespace inclusion syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ data:
     - kube-node-lease
     - registry-proxy
     includeNamespaces:
-    - *
+    - "*"
     podSelector: {}
     namespaceSelector: {}
 ```


### PR DESCRIPTION
Fix error

```
2025/03/11 01:39:32 Reset config failed: yaml: line 15: did not find expected alphabetic or numeric character
```